### PR TITLE
fix: Correct AttributeError by replacing gr.Box with gr.Column

### DIFF
--- a/main.py
+++ b/main.py
@@ -909,7 +909,7 @@ with gr.Blocks(title="CED Asset Manager & Dashboard", css=css) as demo:
     py_modal_trigger_hostname_input = gr.Textbox(label="Python Modal Trigger", visible=False, elem_id="py_modal_trigger_hostname_input")
 
     # Python-driven modal components (defined globally within the Blocks scope)
-    with gr.Box(visible=False, elem_id="py_modal_wrapper") as py_modal_wrapper:
+    with gr.Column(visible=False, elem_id="py_modal_wrapper") as py_modal_wrapper: # Changed gr.Box to gr.Column
         py_modal_content_area = gr.HTML(value="<p>Modal Content Will Load Here...</p>")
         py_close_modal_button = gr.Button("Close Modal")
 


### PR DESCRIPTION
Replaced `gr.Box` with the valid Gradio layout component `gr.Column` for the `py_modal_wrapper` element. This resolves the `AttributeError: module 'gradio' has no attribute 'Box'` and allows the application to run.